### PR TITLE
feat: added fetching from /rpc to get actual data on the application's flags

### DIFF
--- a/src/commands/info.ts
+++ b/src/commands/info.ts
@@ -106,7 +106,8 @@ const info = async (
                             flags[
                                 k as
                                     | 'GuildMembers'
-                                    | 'GuildPresences' as 'MessageContent'
+                                    | 'GuildPresences'
+                                    | 'MessageContent'
                             ]
                                 ? '✅'
                                 : '❌'


### PR DESCRIPTION
by using :id/rpc from discord which is a undocumented endpoint we can get the application data which also includes it's intents, so in general we can have actual display of the client's information